### PR TITLE
Added built in restart of the detektor if the PCSC library throws exception

### DIFF
--- a/KortIUrDetektorApp/KortIUrDetektor.csproj
+++ b/KortIUrDetektorApp/KortIUrDetektor.csproj
@@ -8,10 +8,10 @@
 	<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 	<PlatformTarget>x64</PlatformTarget>
 	<Title>KortIUrDetektor</Title>
-	<Version>0.9.8</Version>
-	<PackageVersion>0.9.8</PackageVersion>
-	<AssemblyVersion>0.9.8</AssemblyVersion>
-	<FileVersion>0.9.8</FileVersion>
+	<Version>0.9.9</Version>
+	<PackageVersion>0.9.9</PackageVersion>
+	<AssemblyVersion>0.9.9</AssemblyVersion>
+	<FileVersion>0.9.9</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/KortIUrDetektorApp/Program.cs
+++ b/KortIUrDetektorApp/Program.cs
@@ -11,24 +11,50 @@ class Program
 {
     static async Task Main()
     {
+        bool normalExit = false;
+        while (!normalExit)
+        {
+            try
+            {
+                await RunApplication();
+                normalExit = true;
+                break; // Normal exit - don't restart
+            }
+            catch (Exception)
+            {
+                await Task.Delay(10000);
+            }
+        }
+    }
+
+    static async Task RunApplication()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        
         IConfiguration configuration = new ConfigurationBuilder()
             .SetBasePath(AppContext.BaseDirectory)
             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
             .Build();
- 
-        var kortIUrConf = configuration.GetSection("KortIUrConf").Get<KortIUrConf>();
 
+        var kortIUrConf = configuration.GetSection("KortIUrConf").Get<KortIUrConf>();
         LogLevel logLevel = configuration.GetValue<LogLevel>("Logging:EventLog:LogLevel:Default");
 
         KortIUrDetektor kortIUrDetektor = new KortIUrDetektor(kortIUrConf, logLevel);
         kortIUrDetektor.InitDetektor();
 
+        // Handle ProcessExit (Task Manager end task, system shutdown)
         AppDomain.CurrentDomain.ProcessExit += kortIUrDetektor.CurrentDomain_ProcessExit;
 
-        // Start the background task
-        Task backgroundTask = Task.Run(() => kortIUrDetektor.BackgroundTaskMethod());
-
-        // Wait for the task to complete or for the user to press Ctrl+C
-        await backgroundTask;
+        try
+        {
+            // Pass the cancellation token to the background method
+            await Task.Run(() => kortIUrDetektor.BackgroundTaskMethod(cancellationTokenSource.Token), 
+                          cancellationTokenSource.Token);
+        }
+        catch (Exception ex)
+        {
+            KortIUrDetektor._logger?.LogError(ex, "KortIUrDetektor Application exception: {Message}", ex.Message);
+            throw;
+        }
     }
 }

--- a/KortIUrInstaller/Package.wxs
+++ b/KortIUrInstaller/Package.wxs
@@ -3,7 +3,7 @@
 <!-- Define the variables in "$(var.*) expressions" -->
 <?define Name = "KortIUrDetektor" ?>
 <?define Manufacturer = "RegionSkane" ?>
-<?define Version = "0.9.8" ?>
+<?define Version = "0.9.9" ?>
 <?define UpgradeCode = "9ED3FF33-8718-444E-B44B-69A2344B7E98" ?>
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
@@ -17,17 +17,13 @@
         <MajorUpgrade DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit." />
 
         <!-- Define the directory structure -->
-        <Directory Id="TARGETDIR" Name="SourceDir">
-            <Directory Id="ProgramFiles64Folder">
-
-                <!-- Create a folder inside program files -->
-                <Directory Id="ROOTDIRECTORY" Name="$(Manufacturer)">
-
-                    <!-- Create a folder within the parent folder given the name -->
-                    <Directory Id="INSTALLFOLDER" Name="$(Name)" />
-                </Directory>
-            </Directory>
-        </Directory>
+		<StandardDirectory Id="ProgramFiles64Folder">
+			<!-- Create a folder inside program files -->
+			<Directory Id="ROOTDIRECTORY" Name="$(Manufacturer)">
+				<!-- Create a folder within the parent folder given the name -->
+				<Directory Id="INSTALLFOLDER" Name="$(Name)" />
+			</Directory>
+		</StandardDirectory>
         <MediaTemplate EmbedCab="yes" />
 
         <!-- The files inside this DirectoryRef are linked to


### PR DESCRIPTION
### Description

Added built in restart of the detektor if the PCSC library throws exception.


### References

#11 

### Testing

Tested on a couple of different windows machines, both win 10 and 11.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in the README.md
- [x] All active GitHub checks for tests, formatting, and security are passing
